### PR TITLE
Add long description to gemspec

### DIFF
--- a/cryptosystem.gemspec
+++ b/cryptosystem.gemspec
@@ -8,6 +8,10 @@ Gem::Specification.new do |s|
   s.version = Cryptosystem::VERSION
   s.files   = `git ls-files`.split($/)
   s.summary = 'Simple asymmetric (public-key) encryption.'
+  s.description = <<-DESC
+    Cryptosystem is a Ruby library facilitating simple encryption and
+    decryption with asymmetric cryptography (or public-key cryptography).
+  DESC
   s.author  = 'Josh Wetzel'
   s.license = 'MIT'
   s.required_ruby_version = '~> 2'


### PR DESCRIPTION
Adds a long description in the gemspec that'll show up on RubyGems.org
to further explain the purpose of the gem.

Protip: I just stole from the README
