### PR TITLE
Require Cryptosystem before Minitest

### DIFF
--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,5 +1,5 @@
-require 'minitest/autorun'
 require 'cryptosystem'
+require 'minitest/autorun'
 
 if !defined?(Minitest::Test)
   Minitest::Test = MiniTest::Unit::TestCase


### PR DESCRIPTION
Require `cryptosystem` before `minitest/autorun`.
