### PR TITLE
Return nil when encrypting or decrypting a nil value

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,3 @@
+#### 0.0.1
+* Encrypting a `nil` value returns `nil` instead of `EncryptError`.
+* Decrypting a `nil` value returns `nil` instead of `DecryptError`.

--- a/lib/cryptosystem/rsa.rb
+++ b/lib/cryptosystem/rsa.rb
@@ -19,12 +19,14 @@ module Cryptosystem
     end
 
     def encrypt(value)
+      return nil if value.nil?
       base64_encode(public_key.public_encrypt(value))
     rescue => error
       raise EncryptError, error.message
     end
 
     def decrypt(value)
+      return nil if value.nil?
       private_key.private_decrypt(base64_decode(value))
     rescue => error
       raise DecryptError, error.message

--- a/lib/cryptosystem/version.rb
+++ b/lib/cryptosystem/version.rb
@@ -1,3 +1,3 @@
 module Cryptosystem
-  VERSION = "0.0.0"
+  VERSION = '0.0.1'.freeze
 end

--- a/test/cryptosystem/rsa_test.rb
+++ b/test/cryptosystem/rsa_test.rb
@@ -29,15 +29,11 @@ class RSATest < Minitest::Test
     assert Base64.strict_encode64(@rsa.decrypt(@rsa.encrypt('test')))
   end
 
-  def test_bad_encrypt_raises_exception
-    assert_raises Cryptosystem::EncryptError do
-      @rsa.encrypt(nil)
-    end
+  def test_encrypting_nil_value_returns_nil
+    assert_nil @rsa.encrypt(nil)
   end
 
-  def test_bad_decrypt_raises_exception
-    assert_raises Cryptosystem::DecryptError do
-      @rsa.decrypt(nil)
-    end
+  def test_decrypting_nil_value_returns_nil
+    assert_nil @rsa.decrypt(nil)
   end
 end


### PR DESCRIPTION
Currently, encrypting or decrypting `nil` values result in errors. This pull request changes the `encrypt` and `decrypt` methods to return `nil` instead of raising exceptions. The version has also been bumped from `0.0.0` to `0.0.1`.
