### PR TITLE
Allow configuration options to be passed in or overridden during instantiation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+#### 0.0.2
+* Allow configuration options to be passed in or overridden during instantiation.
+
 #### 0.0.1
 * Encrypting a `nil` value returns `nil` instead of `EncryptError`.
 * Decrypting a `nil` value returns `nil` instead of `DecryptError`.

--- a/README.md
+++ b/README.md
@@ -33,6 +33,18 @@ Cryptosystem::RSA.configure do |config|
 end
 ```
 
+Configuration options may also be passed in or overridden when instantiating a new object.
+
+```ruby
+config = {
+  password: ENV['secret-password'],
+  private_key_path: 'path/to/private.key',
+  public_key_path: 'path/to/public.pub'
+}
+
+rsa = Cryptosystem::RSA.new(config)
+```
+
 ## Encrypting
 After generating a key pair and properly configuring Cryptosystem, encryption is straightforward.
 

--- a/lib/cryptosystem/rsa.rb
+++ b/lib/cryptosystem/rsa.rb
@@ -10,10 +10,10 @@ module Cryptosystem
     attr_reader :private_key_path
     attr_reader :public_key_path
 
-    def initialize
-      @password = Cryptosystem::RSA.password
-      @private_key_path = expand_path(Cryptosystem::RSA.private_key_path)
-      @public_key_path = expand_path(Cryptosystem::RSA.public_key_path)
+    def initialize(config = {})
+      @password = config[:password] || Cryptosystem::RSA.password
+      @private_key_path = expand_path(config[:private_key_path] || Cryptosystem::RSA.private_key_path)
+      @public_key_path = expand_path(config[:public_key_path] || Cryptosystem::RSA.public_key_path)
     rescue => error
       raise ConfigurationError, error.message
     end

--- a/lib/cryptosystem/version.rb
+++ b/lib/cryptosystem/version.rb
@@ -1,3 +1,3 @@
 module Cryptosystem
-  VERSION = '0.0.1'.freeze
+  VERSION = '0.0.2'.freeze
 end

--- a/test/cryptosystem/rsa_test.rb
+++ b/test/cryptosystem/rsa_test.rb
@@ -6,6 +6,17 @@ class RSATest < Minitest::Test
   end
 
   def test_initialize
+    config = {
+      password: 'override',
+      private_key_path: 'override.key',
+      public_key_path: 'override.pub'
+    }
+
+    rsa = Cryptosystem::RSA.new(config)
+    assert_equal config[:password], rsa.password
+    assert_equal File.expand_path(config[:private_key_path]), rsa.private_key_path
+    assert_equal File.expand_path(config[:public_key_path]), rsa.public_key_path
+
     assert_equal Cryptosystem::RSA.password, @rsa.password
     assert_equal File.expand_path(@rsa.private_key_path), @rsa.private_key_path
     assert_equal File.expand_path(@rsa.public_key_path), @rsa.public_key_path


### PR DESCRIPTION
This pull request allows a configuration hash to be passed in during instantiation. It overrides the configuration options set at the class level. The version was also bumped from `0.0.1` to `0.0.2`.
