### PR TITLE
Test against supported Ruby versions

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -11,12 +11,10 @@ permissions:
 
 jobs:
   test:
-
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        ruby-version: ['2.6', '2.7', '3.0', '3.1']
-
+        ruby-version: ['2.7', '3.0', '3.1', '3.2']
     steps:
     - uses: actions/checkout@v3
     - name: Set up Ruby


### PR DESCRIPTION
Drop support for Ruby 2.6 (EOL) and add support for Ruby 3.2.